### PR TITLE
Second chance saloon

### DIFF
--- a/public/client.js
+++ b/public/client.js
@@ -5,7 +5,7 @@ $( document ).ready(function() {
   function getName() {
     // prompt for person's name before allowing to post
     var name = Cookies.get('name');
-    if(!name) {
+    if(!name || name === 'null') {
       name = window.prompt("What is your name/handle?");
       Cookies.set('name', name);
     }


### PR DESCRIPTION
prompts users who declined to enter a name to enter one when attempting to submit a message; fixes #1
