### PR TITLE
Stops blank messages from being sent

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "hapi": "^8.6.x",
     "hiredis": "^0.4.0",
+    "phantomjs": "^1.9.18",
     "redis": "^0.12.1",
     "socket.io": "^1.3.5",
     "socket.io-client": "^1.3.5"
@@ -53,7 +54,8 @@
     "codeclimate": "CODECLIMATE_REPO_TOKEN=8bdde2e5617587b59c481ef04b710d04a78a6469fcee71840d58da7a839dda6b ./node_modules/codeclimate-test-reporter/bin/codeclimate.js < ./coverage/lcov.info",
     "open-coverage": "open ./test/coverage.html",
     "spec": "node ./node_modules/tape/bin/tape ./test/*.js | node_modules/tap-spec/bin/cmd.js",
-    "start": "PORT=8000 ./node_modules/.bin/nodemon ./server.js"
+    "start": "PORT=8000 ./node_modules/.bin/nodemon ./server.js",
+    "phantom": "./node_modules/.bin/phantomjs /test/phantom.js"
   },
   "pre-commit": [
     "jshint",

--- a/public/client.js
+++ b/public/client.js
@@ -29,6 +29,15 @@ $( document ).ready(function() {
   }
 
   $('form').submit(function() {
+    
+    //if input is empty or white space do not send message
+    if($('#m').val().match(/^[\s]*$/) !== null) { 
+      $('#m').val('');
+      $('#m').attr('placeholder', 'please enter your message here');
+      return false; 
+    }
+
+    
     if(!Cookies.get('name') || Cookies.get('name').length < 1 || Cookies.get('name') === 'null') {
       getName();
       return false;
@@ -36,6 +45,7 @@ $( document ).ready(function() {
       var msg  = $('#m').val();
       socket.emit('io:message', sanitise(msg));
       $('#m').val(''); // clear message form ready for next/new message
+      $('#m').attr('placeholder', ''); //clears placeholder once a msg is successfully sent
       return false;
     }
   });


### PR DESCRIPTION
Stops people who use the app from being able to send blank messages (including messages with just a space in them).

This is done by implementing the lovely @tsop14's solution from the non-riot version of this tutorial (created [here](https://github.com/dwyl/hapi-socketio-redis-chat-example#36)). Fixes #2.
